### PR TITLE
Style SuSiE endpoint pills like FinnGen buttons

### DIFF
--- a/pheweb/serve/static/finngen_susie.js
+++ b/pheweb/serve/static/finngen_susie.js
@@ -187,7 +187,7 @@ function renderFinnGenSusie() {
         a.href        = href;
         a.target      = '_blank';
         a.textContent = ep;
-        a.className = 'susie-pill';
+        a.className = 'btn susie-pill';
 
         summaryEl.appendChild(a);
         });

--- a/pheweb/serve/static/region.css
+++ b/pheweb/serve/static/region.css
@@ -176,6 +176,8 @@ h1 {
 }
 
 .btn:hover {
+    background-color: #3500d38e;
+    color: #FFFFFF;
     transform: scale(1.03);
 }
 
@@ -240,9 +242,4 @@ h1 {
 
 .susie-pill {
     margin: 0 6px 0 0;
-}
-
-.susie-pill:hover {
-    background-color: #3500d38e;
-    color: #FFFFFF;
 }

--- a/pheweb/serve/static/region.css
+++ b/pheweb/serve/static/region.css
@@ -172,6 +172,11 @@ h1 {
     cursor: pointer;
     display: inline-block;
     font-size: 14px;
+    transition: transform 0.1s ease-in-out;
+}
+
+.btn:hover {
+    transform: scale(1.03);
 }
 
 #susie-header {
@@ -234,11 +239,5 @@ h1 {
 }
 
 .susie-pill {
-    display: inline-block;
-    padding: 2px 8px;
-    margin-right: 6px;
-    border-radius: 12px;
-    background: #f0f0f0;
-    text-decoration: underline;
-    color: #007bff;
+    margin: 0 6px 0 0;
 }

--- a/pheweb/serve/static/region.css
+++ b/pheweb/serve/static/region.css
@@ -241,3 +241,8 @@ h1 {
 .susie-pill {
     margin: 0 6px 0 0;
 }
+
+.susie-pill:hover {
+    background-color: #3500d38e;
+    color: #FFFFFF;
+}


### PR DESCRIPTION
## Summary
- restyle SuSiE endpoint pills to reuse existing FinnGen button styles
- add a subtle hover scale effect for buttons

## Testing
- `pre-commit run --files pheweb/serve/static/region.css pheweb/serve/static/finngen_susie.js` *(failed: command not found)*
- `pip install pre-commit` *(failed: Could not find a version that satisfies the requirement pre-commit)*
- `pytest` *(errors: ModuleNotFoundError: No module named 'pheweb')*


------
https://chatgpt.com/codex/tasks/task_e_6895ee974fac833394995265feff3114