### PR TITLE
Align Plotly region plots with LocusZoom width

### DIFF
--- a/pheweb/serve/static/finngen_catalog.js
+++ b/pheweb/serve/static/finngen_catalog.js
@@ -150,9 +150,11 @@ function renderFinnGenPlot() {
       }
 
       // Render the new FinnGen plot
-      Plotly.newPlot('finngen-gwas-catalog', [trace], layout)
+      var plotDiv = document.getElementById('finngen-gwas-catalog');
+      var lzWidth = document.getElementById('lz-1').clientWidth;
+      layout.width = lzWidth;
+      Plotly.newPlot(plotDiv, [trace], layout, {responsive: true})
         .then(function() {
-          var plotDiv = document.getElementById('finngen-gwas-catalog');
           
           // Click event to go to dbSNP page
           plotDiv.on('plotly_click', function(evtData) {
@@ -214,6 +216,10 @@ function renderFinnGenPlot() {
               });
             });
           }
+          window.addEventListener('resize', function() {
+            var newWidth = document.getElementById('lz-1').clientWidth;
+            Plotly.relayout(plotDiv, {width: newWidth});
+          });
         });
 
       // Update the FinnGen button link

--- a/pheweb/serve/static/finngen_susie.js
+++ b/pheweb/serve/static/finngen_susie.js
@@ -194,7 +194,10 @@ function renderFinnGenSusie() {
 
       // Render
       container.innerHTML = '';
-      Plotly.newPlot('finngen-susie', traces, layout).then(function(){
+      var plotDiv = document.getElementById('finngen-susie');
+      var lzWidth = document.getElementById('lz-1').clientWidth;
+      layout.width = lzWidth;
+      Plotly.newPlot(plotDiv, traces, layout, {responsive: true}).then(function(){
         // sync with locuszoom state...
         if (window.plot && window.plot.state) {
           var s = window.plot.state;
@@ -231,6 +234,10 @@ function renderFinnGenSusie() {
             });
           });
         }
+        window.addEventListener('resize', function(){
+          var newWidth = document.getElementById('lz-1').clientWidth;
+          Plotly.relayout(plotDiv, {width: newWidth});
+        });
       });
     })
     .catch(function(err){

--- a/pheweb/serve/static/gwas_catalog.js
+++ b/pheweb/serve/static/gwas_catalog.js
@@ -284,10 +284,12 @@ function renderPlotlyCatalogPlot() {
       }
       
       // Render the Plotly plot.
-      Plotly.newPlot('plotly-gwas-catalog', [traceUKBB, traceEBI], layout)
+      var plotDiv = document.getElementById('plotly-gwas-catalog');
+      var lzWidth = document.getElementById('lz-1').clientWidth;
+      layout.width = lzWidth;
+      Plotly.newPlot(plotDiv, [traceUKBB, traceEBI], layout, {responsive: true})
         .then(function() {
           // Attach a click event listener so that clicking a point opens the PubMed page.
-          var plotDiv = document.getElementById('plotly-gwas-catalog');
 
           // Clicking a point => open PubMed page
           plotDiv.on('plotly_click', function(data) {
@@ -325,6 +327,10 @@ function renderPlotlyCatalogPlot() {
           });
           renderWordCloud(ukbbCustom, 'ukbb-wordcloud', 'ukbb');
           renderWordCloud(ebiCustom, 'gwas-wordcloud', 'gwas');
+          window.addEventListener('resize', function() {
+            var newWidth = document.getElementById('lz-1').clientWidth;
+            Plotly.relayout(plotDiv, {width: newWidth});
+          });
         });
     })
     .catch(function(error) {

--- a/pheweb/serve/static/region.css
+++ b/pheweb/serve/static/region.css
@@ -10,8 +10,9 @@
 
 .lz-container-responsive,
 #plotly-gwas-catalog,
-#finngen-gwas-catalog {
-    overflow-x: auto;
+#finngen-gwas-catalog,
+#finngen-susie {
+    overflow-x: hidden;
 }
 
 #endpoint-row-wrapper {


### PR DESCRIPTION
## Summary
- Hide horizontal overflow for region plots to remove page scroll.
- Match Plotly plot widths to LocusZoom and add resize handlers for GWAS Catalog, FinnGen associations, and SuSiE plots.

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'pheweb')*
- `pre-commit run --files pheweb/serve/static/finngen_catalog.js pheweb/serve/static/finngen_susie.js pheweb/serve/static/gwas_catalog.js pheweb/serve/static/region.css` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6899a41102ac8333bd310a1faa9fbebb