### PR TITLE
Improve SuSiE trait label visibility

### DIFF
--- a/pheweb/serve/static/region.css
+++ b/pheweb/serve/static/region.css
@@ -10,9 +10,12 @@
 
 .lz-container-responsive,
 #plotly-gwas-catalog,
-#finngen-gwas-catalog,
-#finngen-susie {
+#finngen-gwas-catalog {
     overflow-x: hidden;
+}
+
+#finngen-susie {
+    overflow: visible;
 }
 
 #endpoint-row-wrapper {


### PR DESCRIPTION
## Summary
- Wrap long FinnGen SuSiE trait labels and space y-axis accordingly
- Show full label on hover and allow overflow in SuSiE container

## Testing
- `PYTHONPATH=. pytest` *(fails: ModuleNotFoundError: No module named 'boltons')*

------
https://chatgpt.com/codex/tasks/task_e_6899cc65ab9c83338269d4c851bb74d6