### PR TITLE
Add ATC mapping API and display drug names in FinnGen SuSiE

### DIFF
--- a/pheweb/serve/server.py
+++ b/pheweb/serve/server.py
@@ -196,6 +196,29 @@ def api_finngen_susie():
 
     return jsonify({"data": data})
 
+@functools.lru_cache()
+def _load_atc_map() -> Dict[str, str]:
+    """Return mapping of ATC codes to long names."""
+    path = os.path.join(conf.get_data_dir(), "atc.txt")
+    mapping: Dict[str, str] = {}
+    if not os.path.exists(path):
+        return mapping
+    with open(path) as f:
+        for line in f:
+            line = line.strip()
+            if not line or line.startswith("Id"):
+                continue
+            parts = line.split("\t")
+            if len(parts) >= 2:
+                mapping[parts[0]] = parts[1]
+    return mapping
+
+
+@bp.route("/api/atc")
+def api_atc_codes():
+    """Serve mapping from ATC code to human-readable name."""
+    return jsonify(_load_atc_map())
+
 @bp.route("/api/finngen/<endpoint>")
 @check_auth
 def api_finngen(endpoint: str):

--- a/pheweb/serve/static/finngen_susie.js
+++ b/pheweb/serve/static/finngen_susie.js
@@ -10,6 +10,27 @@ function classifyRow(row) {
   return 'endpoint_' + (row.good_cs ? 'good' : 'low');
 }
 
+// cache of ATC code mapping fetched from the backend
+var atcMapPromise = null;
+function getAtcMap() {
+  if (!atcMapPromise) {
+    var url = window.model.urlprefix + '/api/atc';
+    atcMapPromise = fetch(url)
+      .then(function(resp){ return resp.ok ? resp.json() : {}; })
+      .catch(function(){ return {}; });
+  }
+  return atcMapPromise;
+}
+
+function displayEndpoint(ep, atcMap, useNames) {
+  if (!useNames) return ep;
+  var m = ep.match(/^ATC_(.+)_IRN$/);
+  if (m && atcMap[m[1]]) {
+    return atcMap[m[1]];
+  }
+  return ep;
+}
+
 function renderFinnGenSusie() {
   var regionEl = document.getElementById('lz-1');
   if (!regionEl || !regionEl.dataset.region) {
@@ -22,16 +43,22 @@ function renderFinnGenSusie() {
   if (!container) return;
   container.innerHTML = '<p>Loading...</p>';
 
-  fetch(apiUrl)
-    .then(function(response) {
-      if (!response.ok) throw new Error("Failed to fetch SuSiE data");
-      return response.json();
-    })
-    .then(function(json) {
+  Promise.all([
+    fetch(apiUrl).then(function(resp){
+      if (!resp.ok) throw new Error("Failed to fetch SuSiE data");
+      return resp.json();
+    }),
+    getAtcMap()
+  ])
+    .then(function(results) {
+      var json = results[0];
+      var atcMap = results[1];
       var rows = json.data || json;
       var showEP = document.getElementById('show-endpoints').checked;
       var showDG = document.getElementById('show-drugs').checked;
       var showLQ = document.getElementById('show-low-quality').checked;
+      var showNamesEl = document.getElementById('show-atc-names');
+      var showNames = showNamesEl ? showNamesEl.checked : true;
 
       rows = rows.filter(function(r) {
         return isDrug(r) ? showDG : showEP;
@@ -73,7 +100,8 @@ function renderFinnGenSusie() {
       // Build y-axis labels
       var labels = [];
       rows.forEach(function(r) {
-        var lab = r.cs.length>1 ? r.trait + ' (' + ' ×' + r.cs.length + ')' : r.trait;
+        var name = displayEndpoint(r.trait, atcMap, showNames);
+        var lab = r.cs.length>1 ? name + ' (' + ' ×' + r.cs.length + ')' : name;
         r.label = lab;
         if (labels.indexOf(lab) === -1) labels.push(lab);
       });
@@ -217,8 +245,8 @@ function renderFinnGenSusie() {
         plot_bgcolor: 'white'
       };
 
-        var endpoints = labels.map(function(l) {
-        return l.replace(/\s*\(.*\)$/, '');
+        var endpoints = rows.map(function(r) {
+          return r.trait;
         });
         var uniqueEndpoints = Array.from(new Set(endpoints));
         var summaryEl = document.getElementById('susie-summary');
@@ -240,42 +268,42 @@ function renderFinnGenSusie() {
 
 
         uniqueEndpoints.forEach(function(ep) {
-        var m = ep.match(/^ATC_(.+)_IRN$/);
-        var a = document.createElement('a');
-        a.textContent = ep;
-        a.className = 'btn susie-pill';
+          var m = ep.match(/^ATC_(.+)_IRN$/);
+          var a = document.createElement('a');
+          a.textContent = displayEndpoint(ep, atcMap, showNames);
+          a.className = 'btn susie-pill';
 
-        if (m) {
-            // Drug endpoints: keep old behaviour and link to ATC website
-            var code = m[1];
-            a.href   = 'https://atcddd.fhi.no/atc_ddd_index/?code=' + encodeURIComponent(code);
-            a.target = '_blank';
-        } else {
-            // Non-drug endpoints: populate FinnGen catalog search
-            a.href = '#';
-            a.addEventListener('click', function(ev){
-                ev.preventDefault();
-                var searchBox = document.getElementById('endpoint-search');
-                if (searchBox) {
-                    searchBox.value = ep;
-                    var inputEvt = new Event('input', { bubbles: true });
-                    searchBox.dispatchEvent(inputEvt);
-                    var select = document.getElementById('endpoint-select');
-                    if (select) {
-                        select.value = ep;
-                        if (typeof renderFinnGenPlot === 'function') {
-                            renderFinnGenPlot();
-                        }
-                        if (typeof updateFinnGenButton === 'function') {
-                            updateFinnGenButton();
-                        }
-                    }
-                    window.scrollTo({ top: document.documentElement.scrollHeight, behavior: 'smooth' });
-                }
-            });
-        }
+          if (m) {
+              // Drug endpoints: keep old behaviour and link to ATC website
+              var code = m[1];
+              a.href   = 'https://atcddd.fhi.no/atc_ddd_index/?code=' + encodeURIComponent(code);
+              a.target = '_blank';
+          } else {
+              // Non-drug endpoints: populate FinnGen catalog search
+              a.href = '#';
+              a.addEventListener('click', function(ev){
+                  ev.preventDefault();
+                  var searchBox = document.getElementById('endpoint-search');
+                  if (searchBox) {
+                      searchBox.value = ep;
+                      var inputEvt = new Event('input', { bubbles: true });
+                      searchBox.dispatchEvent(inputEvt);
+                      var select = document.getElementById('endpoint-select');
+                      if (select) {
+                          select.value = ep;
+                          if (typeof renderFinnGenPlot === 'function') {
+                              renderFinnGenPlot();
+                          }
+                          if (typeof updateFinnGenButton === 'function') {
+                              updateFinnGenButton();
+                          }
+                      }
+                      window.scrollTo({ top: document.documentElement.scrollHeight, behavior: 'smooth' });
+                  }
+              });
+          }
 
-        summaryEl.appendChild(a);
+          summaryEl.appendChild(a);
         });
 
       // Render
@@ -347,6 +375,7 @@ document.addEventListener('DOMContentLoaded', function(){
   var epToggle = document.getElementById('show-endpoints');
   var dgToggle = document.getElementById('show-drugs');
   var lqToggle = document.getElementById('show-low-quality');
+  var atcToggle = document.getElementById('show-atc-names');
 
   var summary = document.getElementById('susie-summary');
   if (summary) {
@@ -361,5 +390,6 @@ document.addEventListener('DOMContentLoaded', function(){
   if (epToggle) epToggle.addEventListener('change', renderFinnGenSusie);
   if (dgToggle) dgToggle.addEventListener('change', renderFinnGenSusie);
   if (lqToggle) lqToggle.addEventListener('change', renderFinnGenSusie);
+  if (atcToggle) atcToggle.addEventListener('change', renderFinnGenSusie);
 });
 

--- a/pheweb/serve/templates/region.html
+++ b/pheweb/serve/templates/region.html
@@ -92,6 +92,10 @@
           alt="Info" class="info-icon info-icon-inline">
     </a>
   </label>
+  <label>
+    <input type="checkbox" id="show-atc-names" checked>
+    Show drug names
+  </label>
 </div>
 
 <div id="finngen-susie-wrapper">


### PR DESCRIPTION
## Summary
- expose `/api/atc` endpoint serving ATC code to name mapping from `atc.txt`
- use mapping in `finngen_susie.js` to show human-readable drug names with a toggle
- add UI control in `region.html` to toggle drug name display

## Testing
- `pre-commit run --files pheweb/serve/server.py pheweb/serve/static/finngen_susie.js pheweb/serve/templates/region.html` *(fails: command not found)*
- `pip install pre-commit` *(fails: ProxyError - Tunnel connection failed: 403 Forbidden)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'pheweb' / dependency installation issue)*

------
https://chatgpt.com/codex/tasks/task_e_689c779b91508333b0f6bbc10b4c9c33