### PR TITLE
Improve wordcloud layout responsiveness

### DIFF
--- a/pheweb/serve/static/gwas_catalog.js
+++ b/pheweb/serve/static/gwas_catalog.js
@@ -220,6 +220,16 @@ function renderPlotlyCatalogPlot() {
         // Sort descending by count and take the top 50 words
         wordsArray.sort((a, b) => b.count - a.count);
         wordsArray = wordsArray.slice(0, 50);
+
+        const container = document.getElementById(containerId);
+        if (!wordsArray.length) {
+          if (container) {
+            container.style.display = 'none';
+          }
+          return;
+        } else if (container) {
+          container.style.display = '';
+        }
       
         // Use a logarithmic scale for font sizes to prevent domination.
         const minFont = 12;
@@ -238,7 +248,6 @@ function renderPlotlyCatalogPlot() {
         const color = dataset === "ukbb" ? "#9632b8" : "#d43f3a";
       
         // Define dimensions for the word cloud.
-        const container = document.getElementById(containerId);
         const width = container.clientWidth || 600;
         const height = 120;
       
@@ -325,6 +334,15 @@ function renderPlotlyCatalogPlot() {
           });
           renderWordCloud(ukbbCustom, 'ukbb-wordcloud', 'ukbb');
           renderWordCloud(ebiCustom, 'gwas-wordcloud', 'gwas');
+
+          const ukbbWC = document.getElementById('ukbb-wordcloud');
+          const gwasWC = document.getElementById('gwas-wordcloud');
+          if (ukbbWC && gwasWC && ukbbWC.style.display === 'none' && gwasWC.style.display === 'none') {
+            const wcWrapper = document.getElementById('wordclouds');
+            if (wcWrapper) {
+              wcWrapper.style.display = 'none';
+            }
+          }
         });
     })
     .catch(function(error) {

--- a/pheweb/serve/static/region.css
+++ b/pheweb/serve/static/region.css
@@ -22,9 +22,9 @@
     display: flex;
     align-items: center;
     gap: 30px;
-    flex-wrap: nowrap;
+    flex-wrap: wrap;
     width: 100%;
-    margin-bottom: 20px;    
+    margin-bottom: 20px;
   }
 
   #finngen-logo-wrapper {
@@ -38,6 +38,7 @@
     gap: 30px;
     flex: 1;
     min-width: 0;
+    flex-wrap: wrap;
 }
 
 #endpoint-controls label {
@@ -150,10 +151,31 @@ h1 {
 #wordclouds {
     display: flex;
     flex-direction: row;
+    flex-wrap: wrap;
     gap: 10px;
     margin-top: 20px;
-    flex: 1 1 auto;
+    flex: 1 1 300px;
     min-width: 0;
+}
+
+.wordcloud-box {
+    flex: 1 1 300px;
+    min-width: 250px;
+}
+
+@media (max-width: 1200px) {
+    #endpoint-controls-and-traits {
+        flex-direction: column;
+    }
+    #wordclouds {
+        order: -1;
+        width: 100%;
+        margin-top: 0;
+    }
+    #endpoint-controls {
+        max-width: none;
+        width: 100%;
+    }
 }
 
 .error-label {


### PR DESCRIPTION
## Summary
- Make endpoint controls and wordclouds responsive, stacking when space is limited
- Hide empty GWAS wordclouds so they don't consume layout space

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'pheweb')*

------
https://chatgpt.com/codex/tasks/task_e_689d99fec7048333943c1a8daf0b492a