### PR TITLE
Retain FinnGen plot selection

### DIFF
--- a/pheweb/serve/static/finngen_catalog.js
+++ b/pheweb/serve/static/finngen_catalog.js
@@ -423,6 +423,8 @@ function setupEndpointSearch(retries = 8, delay = 200) {
 
       updateEndpointLabel(filtered);
 
+      const currentSelection = select.value;
+
       select.innerHTML = "";
       let placeholder = document.createElement('option');
       placeholder.value = "";
@@ -437,7 +439,10 @@ function setupEndpointSearch(retries = 8, delay = 200) {
         option.textContent = `${ep.endpoint} - ${ep.phenotype}`;
         select.appendChild(option);
       });
-      renderFinnGenPlot();
+
+      if (filtered.some(ep => ep.endpoint === currentSelection)) {
+        select.value = currentSelection;
+      }
     }, 300);
   });
 }

--- a/pheweb/serve/static/finngen_susie.js
+++ b/pheweb/serve/static/finngen_susie.js
@@ -327,20 +327,14 @@ function renderFinnGenSusie() {
                   var searchBox = document.getElementById('endpoint-search');
                   if (searchBox) {
                       searchBox.value = ep;
-                      var inputEvt = new Event('input', { bubbles: true });
-                      searchBox.dispatchEvent(inputEvt);
-                      var select = document.getElementById('endpoint-select');
-                      if (select) {
-                          select.value = ep;
-                          if (typeof renderFinnGenPlot === 'function') {
-                              renderFinnGenPlot();
-                          }
-                          if (typeof updateFinnGenButton === 'function') {
-                              updateFinnGenButton();
-                          }
-                      }
-                      window.scrollTo({ top: document.documentElement.scrollHeight, behavior: 'smooth' });
+                      searchBox.dispatchEvent(new Event('input', { bubbles: true }));
                   }
+                  var select = document.getElementById('endpoint-select');
+                  if (select) {
+                      select.value = ep;
+                      select.dispatchEvent(new Event('change', { bubbles: true }));
+                  }
+                  window.scrollTo({ top: document.documentElement.scrollHeight, behavior: 'smooth' });
               });
           }
 

--- a/pheweb/serve/static/finngen_susie.js
+++ b/pheweb/serve/static/finngen_susie.js
@@ -330,11 +330,21 @@ function renderFinnGenSusie() {
                       searchBox.dispatchEvent(new Event('input', { bubbles: true }));
                   }
                   var select = document.getElementById('endpoint-select');
-                  if (select) {
-                      select.value = ep;
-                      select.dispatchEvent(new Event('change', { bubbles: true }));
+                  if (!select) return;
+                  if (select.value === ep) return; // already selected
+                  var attempts = 0;
+                  function applySelection() {
+                      attempts++;
+                      var optionFound = Array.from(select.options).some(function(o){ return o.value === ep; });
+                      if (optionFound) {
+                          select.value = ep;
+                          select.dispatchEvent(new Event('change', { bubbles: true }));
+                          window.scrollTo({ top: document.documentElement.scrollHeight, behavior: 'smooth' });
+                      } else if (attempts < 20) {
+                          setTimeout(applySelection, 50);
+                      }
                   }
-                  window.scrollTo({ top: document.documentElement.scrollHeight, behavior: 'smooth' });
+                  setTimeout(applySelection, 350);
               });
           }
 

--- a/pheweb/serve/templates/region.html
+++ b/pheweb/serve/templates/region.html
@@ -90,7 +90,7 @@
   </label>
   <label>
     <input type="checkbox" id="show-low-quality">
-    Show low-quality CS
+    Low-quality CS
     <a href="#" class="info-link"
       title="Toggle credible sets where good_cs is false indicating an unreliable credible set">
       <img src="{{ url_for('bp.static', filename='images/info.svg') }}"


### PR DESCRIPTION
## Summary
- preserve current FinnGen plot when endpoint search text changes or is cleared
- treat SuSiE endpoint summary clicks as endpoint selections

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'pheweb')*

------
https://chatgpt.com/codex/tasks/task_e_68ac418776b88333826a67c10637ee64