### PR TITLE
Highlight endpoint dropdown after GWAS word click

### DIFF
--- a/pheweb/serve/static/gwas_catalog.js
+++ b/pheweb/serve/static/gwas_catalog.js
@@ -276,6 +276,7 @@ function renderPlotlyCatalogPlot() {
             .selectAll("text")
               .data(words)
             .enter().append("text")
+              .attr("class", "wordcloud-word")
               .style("font-family", "Impact")
               .style("fill", color)
               .style("cursor", "pointer")
@@ -284,6 +285,12 @@ function renderPlotlyCatalogPlot() {
               .style("font-size", d => d.size + "px")
               .text(d => d.text)
               .on("click", function(d) {
+                const textEl = d3.select(this);
+                const originalSize = parseFloat(textEl.style("font-size"));
+                textEl.style("font-size", (originalSize * 0.95) + "px");
+                setTimeout(function() {
+                  textEl.style("font-size", originalSize + "px");
+                }, 150);
                 const searchBox = document.getElementById('endpoint-search');
                 searchBox.value = d.text;
                 const inputEvent = new Event('input', { bubbles: true });

--- a/pheweb/serve/static/gwas_catalog.js
+++ b/pheweb/serve/static/gwas_catalog.js
@@ -287,7 +287,7 @@ function renderPlotlyCatalogPlot() {
               .on("mouseover", function(d) {
                 const textEl = d3.select(this);
                 textEl.classed('hovered', true);
-                textEl.style("font-size", (d.size * 1.01) + "px");
+                textEl.style("font-size", (d.size * 1.05) + "px");
               })
               .on("mouseout", function(d) {
                 const textEl = d3.select(this);

--- a/pheweb/serve/static/gwas_catalog.js
+++ b/pheweb/serve/static/gwas_catalog.js
@@ -284,12 +284,22 @@ function renderPlotlyCatalogPlot() {
               .attr("transform", d => "translate(" + [d.x, d.y] + ")rotate(" + d.rotate + ")")
               .style("font-size", d => d.size + "px")
               .text(d => d.text)
+              .on("mouseover", function(d) {
+                const textEl = d3.select(this);
+                textEl.classed('hovered', true);
+                textEl.style("font-size", (d.size * 1.01) + "px");
+              })
+              .on("mouseout", function(d) {
+                const textEl = d3.select(this);
+                textEl.classed('hovered', false);
+                textEl.style("font-size", d.size + "px");
+              })
               .on("click", function(d) {
                 const textEl = d3.select(this);
-                const originalSize = parseFloat(textEl.style("font-size"));
-                textEl.style("font-size", (originalSize * 0.95) + "px");
+                textEl.style("font-size", (d.size * 0.95) + "px");
                 setTimeout(function() {
-                  textEl.style("font-size", originalSize + "px");
+                  const finalSize = textEl.classed('hovered') ? d.size * 1.01 : d.size;
+                  textEl.style("font-size", finalSize + "px");
                 }, 150);
                 const searchBox = document.getElementById('endpoint-search');
                 searchBox.value = d.text;

--- a/pheweb/serve/static/gwas_catalog.js
+++ b/pheweb/serve/static/gwas_catalog.js
@@ -288,6 +288,14 @@ function renderPlotlyCatalogPlot() {
                 searchBox.value = d.text;
                 const inputEvent = new Event('input', { bubbles: true });
                 searchBox.dispatchEvent(inputEvent);
+                const endpointSelect = document.getElementById('endpoint-select');
+                if (endpointSelect) {
+                  endpointSelect.classList.add('highlight-dropdown');
+                  clearTimeout(endpointSelect._highlightTimeout);
+                  endpointSelect._highlightTimeout = setTimeout(function() {
+                    endpointSelect.classList.remove('highlight-dropdown');
+                  }, 2000);
+                }
               });
         }
       }

--- a/pheweb/serve/static/region.css
+++ b/pheweb/serve/static/region.css
@@ -58,6 +58,15 @@
     margin-top: 4px;
 }
 
+#endpoint-select {
+    transition: box-shadow 0.3s ease, transform 0.3s ease;
+}
+
+.highlight-dropdown {
+    box-shadow: 0 0 0 3px hsl(255, 100%, 50%);
+    transform: scale(1.05);
+}
+
 h1 {
     word-break: break-word;
     overflow-wrap: break-word;

--- a/pheweb/serve/static/region.css
+++ b/pheweb/serve/static/region.css
@@ -159,6 +159,10 @@ h1 {
   height: auto !important;
 }
 
+.wordcloud-word {
+  transition: font-size 0.1s ease;
+}
+
 @media (max-width: 1200px) {
     #wordclouds {
         order: -1;

--- a/pheweb/serve/static/region.css
+++ b/pheweb/serve/static/region.css
@@ -63,8 +63,8 @@
 }
 
 .highlight-dropdown {
-    box-shadow: 0 0 0 3px hsl(255, 100%, 50%);
-    transform: scale(1.05);
+    box-shadow: 0 0 0 1px hsl(255, 100%, 50%);
+    transform: scale(1.01);
 }
 
 h1 {


### PR DESCRIPTION
## Summary
- Add blue halo highlight to FinnGen endpoint dropdown when a GWAS Catalog word is clicked
- Style the dropdown to animate halo and slight enlargement

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'pheweb')*

------
https://chatgpt.com/codex/tasks/task_e_68ac8aed0c8c8333a87d2debf4133be0