### PR TITLE
Integrate endpoint dropdown into search

### DIFF
--- a/pheweb/serve/static/finngen_catalog.js
+++ b/pheweb/serve/static/finngen_catalog.js
@@ -423,6 +423,30 @@ function setupEndpointSearch(retries = 8, delay = 200) {
       });
     }, 300);
   });
+
+  ['focus', 'click'].forEach(evt => {
+    searchInput.addEventListener(evt, function() {
+      // Re-run the filter to repopulate suggestions and show the list
+      searchInput.dispatchEvent(new Event('input', { bubbles: true }));
+      if (typeof searchInput.showPicker === 'function') {
+        setTimeout(() => {
+          try { searchInput.showPicker(); } catch (e) { /* ignore */ }
+        }, 310); // wait for datalist to update
+      }
+    });
+  });
+}
+
+function handleEndpointSelection() {
+  var searchInput = document.getElementById('endpoint-search');
+  if (!searchInput || !window.allEndpoints) return;
+  const val = searchInput.value.trim();
+  const match = window.allEndpoints.find(ep => ep.endpoint === val);
+  if (match && window.currentEndpoint !== val) {
+    window.currentEndpoint = val;
+    renderFinnGenPlot();
+    updateFinnGenButton();
+  }
 }
 
 // Initialize everything on DOM load
@@ -430,9 +454,6 @@ document.addEventListener("DOMContentLoaded", function() {
   loadEndpoints();
   var searchInput = document.getElementById('endpoint-search');
   if (searchInput) {
-    searchInput.addEventListener('change', function() {
-      renderFinnGenPlot();
-      updateFinnGenButton();
-    });
+    searchInput.addEventListener('change', handleEndpointSelection);
   }
 });

--- a/pheweb/serve/static/finngen_catalog.js
+++ b/pheweb/serve/static/finngen_catalog.js
@@ -9,8 +9,8 @@ function renderFinnGenPlot() {
   }
   var parts = regionData.split(':');
   var chr = parts[0];
-  var endpointSelect = document.getElementById('endpoint-select');
-  var selectedEndpoint = endpointSelect ? endpointSelect.value : "";
+  var searchInput = document.getElementById('endpoint-search');
+  var selectedEndpoint = searchInput ? searchInput.value.trim() : "";
   if (!selectedEndpoint) {
     document.getElementById("finngen-gwas-catalog").innerHTML = "<p>Select an endpoint to view associations.</p>";
     updateFinnGenButton();
@@ -232,10 +232,10 @@ function renderFinnGenPlot() {
 
 // Create or update the FinnGen, Risteys, & Endpoint Browser results buttons
 function updateFinnGenButton() {
-  var endpointSelect = document.getElementById('endpoint-select');
-  if (!endpointSelect) return;
-  var selectedEndpoint = endpointSelect.value;
-  if (!selectedEndpoint || selectedEndpoint.trim() === "") {
+  var searchInput = document.getElementById('endpoint-search');
+  if (!searchInput) return;
+  var selectedEndpoint = searchInput.value.trim();
+  if (!selectedEndpoint) {
     var existing = document.getElementById("finngen-buttons");
     if (existing) {
       existing.remove();
@@ -305,17 +305,14 @@ function updateFinnGenButton() {
 
 function updateEndpointLabel(endpointsList) {
   const endpointLabel = document.getElementById('endpoint-select-label');
-  const endpointSelect = document.getElementById('endpoint-select');
   if (endpointLabel) {
     const count = endpointsList.length;
     if (count === 0) {
       endpointLabel.textContent = "No endpoints match the search terms.";
       endpointLabel.classList.add("error-label");
-      endpointSelect.disabled = true;
     } else {
       endpointLabel.textContent = `${count} matching endpoint${count !== 1 ? "s" : ""}`;
       endpointLabel.classList.remove("error-label");
-      endpointSelect.disabled = false;
     }
   }
 }
@@ -367,20 +364,14 @@ function loadEndpoints() {
       // Update the label to show the total count of endpoints
       updateEndpointLabel(endpoints);
 
-      let select = document.getElementById('endpoint-select');
-      if (select) {
-        select.innerHTML = "";
-        let placeholder = document.createElement('option');
-        placeholder.value = "";
-        placeholder.textContent = "Select an endpoint";
-        placeholder.disabled = true;
-        placeholder.selected = true;
-        select.appendChild(placeholder);
+      let datalist = document.getElementById('endpoint-options');
+      if (datalist) {
+        datalist.innerHTML = "";
         endpoints.forEach(ep => {
           let option = document.createElement('option');
           option.value = ep.endpoint;
-          option.textContent = `${ep.endpoint} - ${ep.phenotype}`;
-          select.appendChild(option);
+          option.label = `${ep.endpoint} - ${ep.phenotype}`;
+          datalist.appendChild(option);
         });
       }
       if (typeof setupEndpointSearch === 'function') {
@@ -393,8 +384,8 @@ function loadEndpoints() {
 // Fuzzy search for endpoints
 function setupEndpointSearch(retries = 8, delay = 200) {
   let searchInput = document.getElementById('endpoint-search');
-  let select = document.getElementById('endpoint-select');
-  if (!searchInput || !select || !window.allEndpoints) {
+  let datalist = document.getElementById('endpoint-options');
+  if (!searchInput || !datalist || !window.allEndpoints) {
     if (retries > 0) {
       setTimeout(() => setupEndpointSearch(retries - 1, Math.round(delay * 1.2)), delay);
     } else {
@@ -423,26 +414,13 @@ function setupEndpointSearch(retries = 8, delay = 200) {
 
       updateEndpointLabel(filtered);
 
-      const currentSelection = select.value;
-
-      select.innerHTML = "";
-      let placeholder = document.createElement('option');
-      placeholder.value = "";
-      placeholder.textContent = "Select an endpoint";
-      placeholder.disabled = true;
-      placeholder.selected = true;
-      select.appendChild(placeholder);
-
+      datalist.innerHTML = "";
       filtered.forEach(ep => {
         let option = document.createElement('option');
         option.value = ep.endpoint;
-        option.textContent = `${ep.endpoint} - ${ep.phenotype}`;
-        select.appendChild(option);
+        option.label = `${ep.endpoint} - ${ep.phenotype}`;
+        datalist.appendChild(option);
       });
-
-      if (filtered.some(ep => ep.endpoint === currentSelection)) {
-        select.value = currentSelection;
-      }
     }, 300);
   });
 }
@@ -450,9 +428,9 @@ function setupEndpointSearch(retries = 8, delay = 200) {
 // Initialize everything on DOM load
 document.addEventListener("DOMContentLoaded", function() {
   loadEndpoints();
-  var select = document.getElementById('endpoint-select');
-  if (select) {
-    select.addEventListener('change', function() {
+  var searchInput = document.getElementById('endpoint-search');
+  if (searchInput) {
+    searchInput.addEventListener('change', function() {
       renderFinnGenPlot();
       updateFinnGenButton();
     });

--- a/pheweb/serve/static/finngen_susie.js
+++ b/pheweb/serve/static/finngen_susie.js
@@ -321,32 +321,18 @@ function renderFinnGenSusie() {
               a.target = '_blank';
           } else {
               // Non-drug endpoints: populate FinnGen catalog search
-              a.href = '#';
-              a.addEventListener('click', function(ev){
-                  ev.preventDefault();
-                  var searchBox = document.getElementById('endpoint-search');
-                  if (searchBox) {
-                      searchBox.value = ep;
-                      searchBox.dispatchEvent(new Event('input', { bubbles: true }));
-                  }
-                  var select = document.getElementById('endpoint-select');
-                  if (!select) return;
-                  if (select.value === ep) return; // already selected
-                  var attempts = 0;
-                  function applySelection() {
-                      attempts++;
-                      var optionFound = Array.from(select.options).some(function(o){ return o.value === ep; });
-                      if (optionFound) {
-                          select.value = ep;
-                          select.dispatchEvent(new Event('change', { bubbles: true }));
-                          window.scrollTo({ top: document.documentElement.scrollHeight, behavior: 'smooth' });
-                      } else if (attempts < 20) {
-                          setTimeout(applySelection, 50);
-                      }
-                  }
-                  setTimeout(applySelection, 350);
-              });
-          }
+          a.href = '#';
+          a.addEventListener('click', function(ev){
+              ev.preventDefault();
+              var searchBox = document.getElementById('endpoint-search');
+              if (searchBox) {
+                  searchBox.value = ep;
+                  searchBox.dispatchEvent(new Event('input', { bubbles: true }));
+                  searchBox.dispatchEvent(new Event('change', { bubbles: true }));
+                  window.scrollTo({ top: document.documentElement.scrollHeight, behavior: 'smooth' });
+              }
+          });
+      }
 
           summaryEl.appendChild(a);
         });
@@ -437,7 +423,7 @@ function renderFinnGenSusie() {
 document.addEventListener('DOMContentLoaded', function(){
   renderFinnGenSusie();
 
-  var sel      = document.getElementById('endpoint-select');
+  var searchInput = document.getElementById('endpoint-search');
   var epToggle = document.getElementById('show-endpoints');
   var dgToggle = document.getElementById('show-drugs');
   var lqToggle = document.getElementById('show-low-quality');
@@ -452,7 +438,7 @@ document.addEventListener('DOMContentLoaded', function(){
     }, { passive: false });
   }
 
-  if (sel)      sel.addEventListener('change', renderFinnGenSusie);
+  if (searchInput) searchInput.addEventListener('change', renderFinnGenSusie);
   if (epToggle) epToggle.addEventListener('change', renderFinnGenSusie);
   if (dgToggle) dgToggle.addEventListener('change', renderFinnGenSusie);
   if (lqToggle) lqToggle.addEventListener('change', renderFinnGenSusie);

--- a/pheweb/serve/static/finngen_susie.js
+++ b/pheweb/serve/static/finngen_susie.js
@@ -438,7 +438,15 @@ document.addEventListener('DOMContentLoaded', function(){
     }, { passive: false });
   }
 
-  if (searchInput) searchInput.addEventListener('change', renderFinnGenSusie);
+  if (searchInput) {
+    searchInput.addEventListener('change', function(){
+      if (!window.allEndpoints) return;
+      const val = searchInput.value.trim();
+      if (window.allEndpoints.find(ep => ep.endpoint === val)) {
+        renderFinnGenSusie();
+      }
+    });
+  }
   if (epToggle) epToggle.addEventListener('change', renderFinnGenSusie);
   if (dgToggle) dgToggle.addEventListener('change', renderFinnGenSusie);
   if (lqToggle) lqToggle.addEventListener('change', renderFinnGenSusie);

--- a/pheweb/serve/static/gwas_catalog.js
+++ b/pheweb/serve/static/gwas_catalog.js
@@ -305,14 +305,7 @@ function renderPlotlyCatalogPlot() {
                 searchBox.value = d.text;
                 const inputEvent = new Event('input', { bubbles: true });
                 searchBox.dispatchEvent(inputEvent);
-                const endpointSelect = document.getElementById('endpoint-select');
-                if (endpointSelect) {
-                  endpointSelect.classList.add('highlight-dropdown');
-                  clearTimeout(endpointSelect._highlightTimeout);
-                  endpointSelect._highlightTimeout = setTimeout(function() {
-                    endpointSelect.classList.remove('highlight-dropdown');
-                  }, 2000);
-                }
+                searchBox.dispatchEvent(new Event('change', { bubbles: true }));
               });
         }
       }

--- a/pheweb/serve/static/region.css
+++ b/pheweb/serve/static/region.css
@@ -42,8 +42,8 @@
     display: flex;
     flex-direction: column;
     font-size: 14px;
-    flex: 1 1 300px;
-    max-width: 300px;
+    flex: 1 1 600px;
+    max-width: 600px;
     min-width: 0;
 }
 
@@ -53,8 +53,10 @@
 }
 #endpoint-search {
     width: 100%;
-    max-width: 300px;
     margin-top: 4px;
+    padding: 6px 8px;
+    border: 1px solid #ccc;
+    border-radius: 4px;
 }
 
 h1 {

--- a/pheweb/serve/static/region.css
+++ b/pheweb/serve/static/region.css
@@ -51,20 +51,10 @@
     display: block;
     margin-top: 8px;
 }
-#endpoint-search,
-#endpoint-select {
+#endpoint-search {
     width: 100%;
     max-width: 300px;
     margin-top: 4px;
-}
-
-#endpoint-select {
-    transition: box-shadow 0.3s ease, transform 0.3s ease;
-}
-
-.highlight-dropdown {
-    box-shadow: 0 0 0 1px hsl(255, 100%, 50%);
-    transform: scale(1.01);
 }
 
 h1 {
@@ -178,12 +168,6 @@ h1 {
 
 .error-label {
     color: #cc0000;
-}
-
-#endpoint-select:disabled {
-    background-color: #f0f0f0;
-    color: #888;
-    cursor: not-allowed;
 }
 
 .btn {

--- a/pheweb/serve/templates/region.html
+++ b/pheweb/serve/templates/region.html
@@ -120,9 +120,9 @@
           <label for="endpoint-search">
             Search Endpoints
           </label>
-          <input type="text" id="endpoint-search" placeholder="Enter a FinnGen endpoint or phenotype..." />
-          <label for="endpoint-select" id="endpoint-select-label"></label>
-          <select id="endpoint-select"></select>
+          <input type="text" id="endpoint-search" list="endpoint-options" placeholder="Enter a FinnGen endpoint or phenotype..." />
+          <label id="endpoint-select-label"></label>
+          <datalist id="endpoint-options"></datalist>
         </div>
       </div>
       <div id="wordclouds">


### PR DESCRIPTION
## Summary
- Replace endpoint dropdown with datalist-driven search input
- Update plots and buttons to react to search box changes
- Drop obsolete dropdown styles and event wiring

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'pheweb')*


------
https://chatgpt.com/codex/tasks/task_e_68ad780f6e888333a025d475a84a2c30