### PR TITLE
Add mock data generator and static demo site script

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,10 @@ To hide the button for downloading top hits and phenotypes, add `download_top_hi
 
 To allow dynamically filtering the manhattan plot, run `pheweb best-of-pheno` and set `show_manhattan_filter_button=True` in `config.py`.
 
+## Static demo and GitHub Pages
+A tiny mock dataset and helper script can build a read-only PheWeb snapshot suitable for GitHub Pages.
+Run `./etc/build_demo_pages.sh <output_dir>` and publish the generated `localhost:5000` folder on your `gh-pages` branch.
+
 # Modifying PheWeb
 
 See instructions [here](etc/detailed-development-instructions.md).

--- a/etc/build_demo_pages.sh
+++ b/etc/build_demo_pages.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# Build a static PheWeb site using the mock dataset.
+# The resulting site can be served with GitHub Pages.
+set -euo pipefail
+
+OUTDIR=${1:-demo-site}
+PHEWEB=${PHEWEB:-pheweb}
+
+# Generate mock data
+DATA_DIR=$(mktemp -d)
+python "$(dirname "$0")/create_mock_data.py" "$DATA_DIR"
+CACHE_DIR="$DATA_DIR/cache"
+mkdir -p "$CACHE_DIR"
+
+# Prepare phenolist and process data
+$PHEWEB conf data_dir="$DATA_DIR" cache="$CACHE_DIR" phenolist glob --simple-phenocode "$DATA_DIR/assoc-files/*"
+$PHEWEB conf data_dir="$DATA_DIR" cache="$CACHE_DIR" phenolist unique-phenocode
+$PHEWEB conf data_dir="$DATA_DIR" cache="$CACHE_DIR" phenolist read-info-from-association-files
+$PHEWEB conf data_dir="$DATA_DIR" cache="$CACHE_DIR" phenolist import-phenolist -f "$DATA_DIR/pheno-list-categories.json" "$DATA_DIR/categories.csv"
+$PHEWEB conf data_dir="$DATA_DIR" cache="$CACHE_DIR" phenolist merge-in-info "$DATA_DIR/pheno-list-categories.json"
+$PHEWEB conf data_dir="$DATA_DIR" cache="$CACHE_DIR" phenolist verify --required-columns=category
+$PHEWEB conf data_dir="$DATA_DIR" cache="$CACHE_DIR" process
+$PHEWEB conf data_dir="$DATA_DIR" cache="$CACHE_DIR" top-loci
+$PHEWEB conf data_dir="$DATA_DIR" cache="$CACHE_DIR" best-of-pheno
+
+# Start server in background
+$PHEWEB conf data_dir="$DATA_DIR" cache="$CACHE_DIR" serve &
+SERVER_PID=$!
+# Wait for server to start
+sleep 5
+
+# Mirror the site
+rm -rf "$OUTDIR"
+wget --recursive --no-clobber --page-requisites --html-extension --convert-links \
+     --no-parent --domains localhost:5000 --directory-prefix="$OUTDIR" \
+     http://localhost:5000/ \
+     http://localhost:5000/top_hits \
+     http://localhost:5000/pheno/demo \
+     http://localhost:5000/variant/1:869334-G-A
+
+# Shutdown server
+kill $SERVER_PID
+
+SITE_DIR="$OUTDIR/localhost:5000"
+echo "Static site generated in $SITE_DIR"

--- a/etc/create_mock_data.py
+++ b/etc/create_mock_data.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+"""Create a tiny mock dataset for building a demo PheWeb site.
+
+This script writes a minimal set of association results and accompanying
+metadata into an output directory.  The resulting directory can be used as
+`data_dir` for `pheweb` commands.
+"""
+
+import os
+import pathlib
+
+VARIANTS = [
+    ("G", "A", 869334, 1, 0.1, 2e-6),
+    ("T", "C", 1930553, 1, 0.1, 2e-4),
+    ("A", "T", 1931299, 1, 0.5, 3e-11),
+    ("G", "C", 1932181, 1, 0.04, 1e-12),
+    ("G", "C", 1935075, 1, 0.5, 6e-8),
+]
+
+
+def write_assoc_file(outdir: pathlib.Path) -> None:
+    assoc_dir = outdir / "assoc-files"
+    assoc_dir.mkdir(parents=True, exist_ok=True)
+    assoc_path = assoc_dir / "demo.tsv"
+    with assoc_path.open("w") as f:
+        f.write("ref\talt\tbeg\tchrom\tmaf\tpval\n")
+        for ref, alt, beg, chrom, maf, pval in VARIANTS:
+            f.write(f"{ref}\t{alt}\t{beg}\t{chrom}\t{maf}\t{pval}\n")
+
+
+def write_categories(outdir: pathlib.Path) -> None:
+    with (outdir / "categories.csv").open("w") as f:
+        f.write("phenocode,category\n")
+        f.write("demo,Demo\n")
+
+
+def write_correlations(outdir: pathlib.Path) -> None:
+    with (outdir / "pheno-correlations.txt").open("w") as f:
+        f.write("Trait1\tTrait2\trg\tSE\tZ\tP-value\tMethod\n")
+        f.write("demo\tdemo\t1\t0\t0\t0\tmock\n")
+
+
+def main(outdir: str) -> None:
+    outpath = pathlib.Path(outdir)
+    outpath.mkdir(parents=True, exist_ok=True)
+    write_assoc_file(outpath)
+    write_categories(outpath)
+    write_correlations(outpath)
+    print(f"Mock data written to {outpath}")
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "outdir", nargs="?", default="mock-data", help="output directory for mock data"
+    )
+    args = parser.parse_args()
+    main(args.outdir)


### PR DESCRIPTION
## Summary
- add `create_mock_data.py` to produce tiny synthetic dataset
- add `build_demo_pages.sh` to process mock data and snapshot pages for GitHub Pages
- document static demo workflow in README

## Testing
- `./etc/build_demo_pages.sh /tmp/site`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b03c1c4ab48333a4aa73b6683baec7