### PR TITLE
feat: add theme toggle respecting system preference

### DIFF
--- a/pheweb/serve/static/common.js
+++ b/pheweb/serve/static/common.js
@@ -2,6 +2,61 @@
 
 window.debug = window.debug || {};
 
+// Theme handling
+(function() {
+    const media = window.matchMedia('(prefers-color-scheme: dark)');
+
+    function getStored() {
+        return localStorage.getItem('theme') || 'auto';
+    }
+
+    function preferred(theme) {
+        if (theme === 'auto') {
+            return media.matches ? 'dark' : 'light';
+        }
+        return theme;
+    }
+
+    function apply(theme) {
+        document.documentElement.setAttribute('data-bs-theme', preferred(theme));
+    }
+
+    function updateIcon(theme) {
+        const icon = document.getElementById('theme-toggle-icon');
+        if (!icon) return;
+        icon.classList.remove('bi-circle-half', 'bi-moon-fill', 'bi-sun-fill');
+        if (theme === 'auto') icon.classList.add('bi-circle-half');
+        else if (theme === 'dark') icon.classList.add('bi-moon-fill');
+        else icon.classList.add('bi-sun-fill');
+    }
+
+    function setTheme(theme) {
+        localStorage.setItem('theme', theme);
+        apply(theme);
+        updateIcon(theme);
+    }
+
+    function cycle() {
+        const order = ['auto', 'dark', 'light'];
+        const current = getStored();
+        const next = order[(order.indexOf(current) + 1) % order.length];
+        setTheme(next);
+    }
+
+    document.addEventListener('DOMContentLoaded', () => {
+        updateIcon(getStored());
+        const btn = document.getElementById('theme-toggle');
+        if (btn) btn.addEventListener('click', cycle);
+    });
+
+    media.addEventListener('change', () => {
+        if (getStored() === 'auto') apply('auto');
+    });
+
+    // expose for debugging if needed
+    window.phewebTheme = {getStored, setTheme};
+})();
+
 // deal with IE11 problems
 if (!Math.log10) { Math.log10 = function(x) { return Math.log(x) / Math.LN10; }; }
 if (!!window.MSInputMethodContext && !!document.documentMode) { /*ie11*/ $('<style type=text/css>.lz-locuszoom {height: 400px;}</style>').appendTo($('head')); }

--- a/pheweb/serve/templates/layout.html
+++ b/pheweb/serve/templates/layout.html
@@ -4,6 +4,17 @@
     <title>{% include 'title.html' %}</title>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
+    <script>
+      (function() {
+        const stored = localStorage.getItem('theme') || 'auto';
+        const media = window.matchMedia('(prefers-color-scheme: dark)');
+        function apply(t) {
+          const theme = t === 'auto' ? (media.matches ? 'dark' : 'light') : t;
+          document.documentElement.setAttribute('data-bs-theme', theme);
+        }
+        apply(stored);
+      })();
+    </script>
     <link rel="stylesheet" href="https://cdn.datatables.net/1.12.1/css/jquery.dataTables.min.css">
     <link rel="stylesheet" href="https://cdn.datatables.net/1.12.1/css/dataTables.bootstrap5.min.css">
     <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
@@ -50,12 +61,12 @@
   </head>
 
   <body>
-    <nav class="navbar navbar-light bg-light">
+    <nav class="navbar bg-body-tertiary">
       <div class="container-fluid">
         <!-- Left side: Brand and search form -->
         <div class="d-flex align-items-center">
           {% block navbar_left %}
-          <a class="navbar-brand fw-bold text-dark fs-5 mb-0" href="{{ url_for('.homepage') }}">PheWeb</a>
+          <a class="navbar-brand fw-bold text-body fs-5 mb-0" href="{{ url_for('.homepage') }}">PheWeb</a>
           <div id="navbar_form_container" class="ms-3">
             <form action="{{ url_for('.go') }}" class="d-flex" role="search">
               <input id="navbar-searchbox-input" name="query" class="form-control me-2 typeahead" autocomplete="off" type="text" placeholder="Search...">
@@ -67,24 +78,29 @@
         <!-- Right side: Navigation links shown horizontally -->
         <ul class="navbar-nav d-flex flex-row ms-auto mb-0">
           <li class="nav-item me-3">
-            <a class="nav-link fw-bold text-dark" href="{{ url_for('.phenotypes_page') }}">Phenotypes</a>
+            <a class="nav-link fw-bold text-body" href="{{ url_for('.phenotypes_page') }}">Phenotypes</a>
           </li>
           <li class="nav-item me-3">
-            <a class="nav-link fw-bold text-dark" href="{{ url_for('.top_hits_page') }}">Top hits</a>
+            <a class="nav-link fw-bold text-body" href="{{ url_for('.top_hits_page') }}">Top hits</a>
           </li>
           <li class="nav-item me-3 d-flex align-items-center">
-            <a href="https://github.com/veetir/pheweb/" 
-               target="_blank" 
-               class="nav-link text-muted d-flex align-items-center p-0" 
+            <a href="https://github.com/veetir/pheweb/"
+               target="_blank"
+               class="nav-link text-muted d-flex align-items-center p-0"
                style="text-decoration: none;"
-               data-bs-toggle="tooltip" 
+               data-bs-toggle="tooltip"
                title="PheWeb GRCh{{ config.GRCH_BUILD_NUMBER }}">
               <i class="bi bi-github" style="font-size: 1rem;"></i>
             </a>
           </li>
-        </ul>        
+          <li class="nav-item me-3 d-flex align-items-center">
+            <button id="theme-toggle" class="btn btn-link nav-link p-0" type="button" aria-label="Toggle color mode">
+              <i id="theme-toggle-icon" class="bi"></i>
+            </button>
+          </li>
+        </ul>
       </div>
-    </nav>   
+    </nav>
     
     <!-- Main content area -->
     <div class="content container-fluid">


### PR DESCRIPTION
## Summary
- add theme toggle button cycling auto/dark/light
- honor system color scheme preference
- enable theme persistence across pages

## Testing
- `pytest`
- `bash tests/run-all.sh`

------
https://chatgpt.com/codex/tasks/task_e_68b164b490848333a78ec0a996890212